### PR TITLE
fix(multiselect): fix bug removing cacheOption in selectedOptions

### DIFF
--- a/packages/chakra-components/src/MultiSelect/index.js
+++ b/packages/chakra-components/src/MultiSelect/index.js
@@ -101,6 +101,7 @@ const MultiSelect = forwardRef(
       getOptionProps,
       removeSelectedValue,
       removeAllSelectedValues,
+      originalOptions,
       setOriginalOptions,
       setIsOpen,
     } = useComboBox({
@@ -152,7 +153,7 @@ const MultiSelect = forwardRef(
                 }
               }
               onEmptyInputValue(options);
-              setOriginalOptions(options);
+              if (!originalOptions.length) setOriginalOptions(options);
             };
 
             if (typeof defaultOptions === "boolean" && defaultOptions) {
@@ -179,6 +180,7 @@ const MultiSelect = forwardRef(
       }
     }, [
       options,
+      originalOptions,
       isAsync,
       defaultOptions,
       loadOptions,

--- a/packages/chakra-components/src/MultiSelect/useComboBox.js
+++ b/packages/chakra-components/src/MultiSelect/useComboBox.js
@@ -234,6 +234,7 @@ export const useComboBox = ({
   const {
     values,
     selectedOptions,
+    originalOptions,
     filteredOptions,
     inputValue,
     listBoxInputValue,
@@ -606,6 +607,7 @@ export const useComboBox = ({
     getOptionProps,
     removeSelectedValue,
     removeAllSelectedValues,
+    originalOptions,
     setOriginalOptions,
     setIsOpen,
   };


### PR DESCRIPTION
While writing the docs, I noticed removing the cacheOptions introduced a bug that made all the selected option to get reset to null.
Setting the Original Option once solved it